### PR TITLE
docs: Updating the chapter references in step 4

### DIFF
--- a/HMM Tagger.ipynb
+++ b/HMM Tagger.ipynb
@@ -819,7 +819,7 @@
     "    Laplace smoothing is a technique where you add a small, non-zero value to all observed counts to offset for unobserved values.\n",
     "\n",
     "- Backoff Smoothing\n",
-    "    Another smoothing technique is to interpolate between n-grams for missing data. This method is more effective than Laplace smoothing at combatting the data sparsity problem. Refer to chapters 4, 9, and 10 of the [Speech & Language Processing](https://web.stanford.edu/~jurafsky/slp3/) book for more information.\n",
+    "    Another smoothing technique is to interpolate between n-grams for missing data. This method is more effective than Laplace smoothing at combatting the data sparsity problem. Refer to chapters 3 and 26 of the [Speech & Language Processing](https://web.stanford.edu/~jurafsky/slp3/) book for more information.\n",
     "\n",
     "- Extending to Trigrams\n",
     "    HMM taggers have achieved better than 96% accuracy on this dataset with the full Penn treebank tagset using an architecture described in [this](http://www.coli.uni-saarland.de/~thorsten/publications/Brants-ANLP00.pdf) paper. Altering your HMM to achieve the same performance would require implementing deleted interpolation (described in the paper), incorporating trigram probabilities in your frequency tables, and re-implementing the Viterbi algorithm to consider three consecutive states instead of two.\n",

--- a/HMM Tagger.ipynb
+++ b/HMM Tagger.ipynb
@@ -819,7 +819,7 @@
     "    Laplace smoothing is a technique where you add a small, non-zero value to all observed counts to offset for unobserved values.\n",
     "\n",
     "- Backoff Smoothing\n",
-    "    Another smoothing technique is to interpolate between n-grams for missing data. This method is more effective than Laplace smoothing at combatting the data sparsity problem. Refer to chapters 3 and 26 of the [Speech & Language Processing](https://web.stanford.edu/~jurafsky/slp3/) book for more information.\n",
+    "    Another smoothing technique is to interpolate between n-grams for missing data. This method is more effective than Laplace smoothing at combatting the data sparsity problem. Refer to chapters 3 and 26 of the [Speech & Language Processing](https://web.stanford.edu/~jurafsky/slp3/) book, or to this [video lecture](https://youtu.be/oZHRFj8heWM) by the same author, for more information.\n",
     "\n",
     "- Extending to Trigrams\n",
     "    HMM taggers have achieved better than 96% accuracy on this dataset with the full Penn treebank tagset using an architecture described in [this](http://www.coli.uni-saarland.de/~thorsten/publications/Brants-ANLP00.pdf) paper. Altering your HMM to achieve the same performance would require implementing deleted interpolation (described in the paper), incorporating trigram probabilities in your frequency tables, and re-implementing the Viterbi algorithm to consider three consecutive states instead of two.\n",


### PR DESCRIPTION
The Chapters references mentioned refer to the second edition
of the Speech and Language Processing textbook, while the provided link
refers to the current edition, the third edition, which have been restructured.
In the third edition, as of December 30, 2020 draft release
the following changes have been amended:
Chapter 4 of the 2nd ed. is now Chapter 3 of the 3rd ed. ,
Chapter 9 of the 2nd ed. is now Chapter 26 of the 3rd ed. ,
Chapter 10 of the 2nd ed. content have been discarded.